### PR TITLE
PJ_SIM_CHATGPT_2023-16 Translation: Implement Dropdown UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,11 +13,57 @@
   "main": "./out/extension.js",
   "contributes": {
     "menus": {
+      "editor/context": [
+        {
+          "submenu": "myextensionfesubmenu",
+          "group": "navigation"
+        },
+        {
+          "submenu": "myextensionbesubmenu",
+          "group": "navigation"
+        }
+      ],
       "view/title": [
         {
           "command": "sim-chatgpt-translator.runApiKey",
           "group": "navigation",
           "when": "view == sim-chatgpt-translator-sidebar"
+        }
+      ],
+      "myextensionfesubmenu": [
+        {
+          "command": "sim-chatgpt-unit-test.runCypress",
+          "group": "navigation"
+        },
+        {
+          "command": "sim-chatgpt-unit-test.runStorybook",
+          "group": "navigation"
+        },
+        {
+          "command": "sim-chatgpt-unit-test.runPuppeteer",
+          "group": "navigation"
+        },
+        {
+          "command": "sim-chatgpt-unit-test.runPlaywright",
+          "group": "navigation"
+        }
+      ],
+      "myextensionbesubmenu": [
+        {
+          "command": "sim-chatgpt-unit-test.runCypress",
+          "group": "navigation"
+        },
+       {
+          "command": "sim-chatgpt-unit-test.runPHPUnit",
+          "group": "navigation"
+        },
+        {
+          "command": "sim-chatgpt-unit-test.runPyTest",
+          "group": "navigation"
+        },
+        {
+          "command": "sim-chatgpt-unit-test.runRSpec",
+          "group": "navigation"
         }
       ]
     },
@@ -41,13 +87,52 @@
         }
       ]
     },
+    "submenus": [
+      {
+        "label": "FE: Translate code to",
+        "id": "myextensionfesubmenu"
+      },
+      {
+        "label": "BE: Translate code to",
+        "id": "myextensionbesubmenu"
+      }
+    ],
     "commands": [
       {
         "command": "sim-chatgpt-translator.runApiKey",
         "title": "ChatGPT API Key",
         "icon": "media/icons/key.svg"
+      },
+      {
+        "command": "sim-chatgpt-unit-test.runCypress",
+        "title": "Cypress"
+      },
+      {
+        "command": "sim-chatgpt-unit-test.runPuppeteer",
+        "title": "Puppeteer"
+      },
+      {
+        "command": "sim-chatgpt-unit-test.runStorybook",
+        "title": "Storybook"
+      },
+      {
+        "command": "sim-chatgpt-unit-test.runPlaywright",
+        "title": "Playwright"
+      },
+      {
+        "command": "sim-chatgpt-unit-test.runPHPUnit",
+        "title": "PHPUnit   "
+      },
+      {
+        "command": "sim-chatgpt-unit-test.runPyTest",
+        "title": "PyTest"
+      },
+      {
+        "command": "sim-chatgpt-unit-test.runRSpec",
+        "title": "RSpec"
       }
     ]
+
   },
   "scripts": {
     "vscode:prepublish": "yarn run compile",

--- a/package.json
+++ b/package.json
@@ -32,37 +32,37 @@
       ],
       "myextensionfesubmenu": [
         {
-          "command": "sim-chatgpt-unit-test.runCypress",
+          "command": "sim-chatgpt-translator.runJavaScript",
           "group": "navigation"
         },
         {
-          "command": "sim-chatgpt-unit-test.runStorybook",
+          "command": "sim-chatgpt-translator.runTypeScript",
           "group": "navigation"
         },
         {
-          "command": "sim-chatgpt-unit-test.runPuppeteer",
+          "command": "sim-chatgpt-translator.runReact",
           "group": "navigation"
         },
         {
-          "command": "sim-chatgpt-unit-test.runPlaywright",
+          "command": "sim-chatgpt-translator.runVue",
           "group": "navigation"
         }
       ],
       "myextensionbesubmenu": [
         {
-          "command": "sim-chatgpt-unit-test.runCypress",
+          "command": "sim-chatgpt-translator.runPython",
           "group": "navigation"
         },
        {
-          "command": "sim-chatgpt-unit-test.runPHPUnit",
+          "command": "sim-chatgpt-translator.runPHP",
           "group": "navigation"
         },
         {
-          "command": "sim-chatgpt-unit-test.runPyTest",
+          "command": "sim-chatgpt-translator.runRuby",
           "group": "navigation"
         },
         {
-          "command": "sim-chatgpt-unit-test.runRSpec",
+          "command": "sim-chatgpt-translator.runC#",
           "group": "navigation"
         }
       ]
@@ -104,32 +104,36 @@
         "icon": "media/icons/key.svg"
       },
       {
-        "command": "sim-chatgpt-unit-test.runCypress",
-        "title": "Cypress"
+        "command": "sim-chatgpt-translator.runReact",
+        "title": "React"
       },
       {
-        "command": "sim-chatgpt-unit-test.runPuppeteer",
-        "title": "Puppeteer"
+        "command": "sim-chatgpt-translator.runJavaScript",
+        "title": "Javascript"
       },
       {
-        "command": "sim-chatgpt-unit-test.runStorybook",
-        "title": "Storybook"
+        "command": "sim-chatgpt-translator.runTypeScript",
+        "title": "TypeScript"
       },
       {
-        "command": "sim-chatgpt-unit-test.runPlaywright",
-        "title": "Playwright"
+        "command": "sim-chatgpt-translator.runVue",
+        "title": "Vue"
       },
       {
-        "command": "sim-chatgpt-unit-test.runPHPUnit",
-        "title": "PHPUnit   "
+        "command": "sim-chatgpt-translator.runPython",
+        "title": "Python"
       },
       {
-        "command": "sim-chatgpt-unit-test.runPyTest",
-        "title": "PyTest"
+        "command": "sim-chatgpt-translator.runPHP",
+        "title": "Php"
       },
       {
-        "command": "sim-chatgpt-unit-test.runRSpec",
-        "title": "RSpec"
+        "command": "sim-chatgpt-translator.runRuby",
+        "title": "Ruby"
+      },
+      {
+        "command": "sim-chatgpt-translator.runC#",
+        "title": "C#"
       }
     ]
 


### PR DESCRIPTION
## Links
https://framgiaph.backlog.com/board/PJ_SIM_CHATGPT_2023?selectedIssueKey=PJ_SIM_CHATGPT_2023-16

## Description
Create dropdown UI (context menu/submenu) that shows BE/FE testing Framework
FE Languages:
- JavaScript
- TypeScript
- React
- Vue

BE Languages:
- PHP
- Ruby
- Python
- C#

## Notes
N/A
## Screenshots
![image](https://github.com/framgia/sph-ChatGPT/assets/106945745/8ee371ef-f982-4d8e-b86c-b3e145f6cb6c)

