### PR TITLE
PJ_SIM_CHATGPT_2023-17 Translation: Add input field for API Key

### DIFF
--- a/media/js/main.js
+++ b/media/js/main.js
@@ -1,0 +1,61 @@
+'use strict';
+//@ts-check
+// This script will be run within the webview itself
+// It cannot access the main VS Code APIs directly.
+(function () {
+  const vscode = acquireVsCodeApi();
+  document.getElementById('myForm').addEventListener('submit', handleSubmit);
+  window.addEventListener(
+    'load',
+    () => {
+      vscode.postMessage({ type: 'getApiKey', value: null });
+    },
+    { capture: true }
+  );
+  window.addEventListener('message', (event) => {
+    const message = event.data;
+    switch (message.type) {
+      case 'isApiKeyClicked': {
+        let form = document.getElementById('myForm');
+        if (form.classList.contains('hidden')) {
+          getApiInputField('visible');
+        } else {
+          getApiInputField('hidden');
+        }
+        break;
+      }
+      case 'onLoadApiKey': {
+        if (message.value) {
+          getApiInputField('hidden');
+        }
+        break;
+      }
+    }
+  });
+
+  function handleSubmit(event) {
+    event.preventDefault();
+    let apiKeyInput = document.getElementById('api-key');
+    let apiKey = apiKeyInput.value.trim();
+    if (apiKey !== '') {
+      getApiInputField('hidden');
+      vscode.postMessage({ type: 'saveApiKey', value: apiKey });
+    }
+  }
+
+  function getApiInputField(visibility) {
+    let form = document.getElementById('myForm');
+    let message = document.getElementById('message');
+    let divider = document.getElementById('divider');
+    if (visibility === 'hidden') {
+      message.classList.add(visibility);
+      form.classList.add(visibility);
+      divider.classList.add(visibility);
+    } else {
+      message.classList.remove('hidden');
+      form.classList.remove('hidden');
+      divider.classList.remove('hidden');
+    }
+    document.getElementById('myForm').reset();
+  }
+})();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,12 +2,23 @@ import * as vscode from 'vscode';
 import { SidebarProvider } from './providers/SidebarProvider';
 
 export function activate(context: vscode.ExtensionContext) {
-  const sidebarProvider = new SidebarProvider(context.extensionUri);
+  const sidebarProvider = new SidebarProvider(context);
   const sidebarDisposable = vscode.window.registerWebviewViewProvider(
     'sim-chatgpt-translator-sidebar',
     sidebarProvider
   );
   context.subscriptions.push(sidebarDisposable);
+
+  const apiKeyCommandDisposable = vscode.commands.registerCommand(
+    'sim-chatgpt-translator.runApiKey',
+    () => {
+      sidebarProvider._view?.webview.postMessage({
+        type: 'isApiKeyClicked',
+        value: true,
+      });
+    }
+  );
+  context.subscriptions.push(apiKeyCommandDisposable);
 }
 
 // This method is called when your extension is deactivated


### PR DESCRIPTION
## Links
https://framgiaph.backlog.com/view/PJ_SIM_CHATGPT_2023-17
## Description
- Add input field for API key in the sidebar
- Add submit function
- Store in vscode secret storage for persistence
## Notes
- Press f5
- Add yout api key or test with first with any text
- It should persist the key inputted
## Screenshots
![image](https://github.com/framgia/sph-ChatGPT/assets/110364637/aecef04e-1e9c-496d-8a5e-e8734f50bb71)

